### PR TITLE
Updated to allow provisioning of two enrollees at the same time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /dpp-configurator
 /credential.json
 /start.txt
-
+/channel6_configurator

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
 /data.txt
+/dpp-configurator
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.o
 /data.txt
 /dpp-configurator
+/credential.json
+
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /data.txt
 /dpp-configurator
 /credential.json
-
+/start.txt
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ A collection of programs created to implement a configurator for Wi-Fi Easy Conn
    $ git clone --recursive git@github.com:nomlab/dpp-configurator.git
    ```
 
+# Priparation
+1. Edit `credential.json.sample`
+   
+   Set ssid and password for access point
+   ```
+   {"wi-fi_tech":"infra","discovery":{"ssid":"<SSID>"},"cred":{"akm":"psk","pass":"<PASSWORD>"}}
+   ```
+2. Rename file from `credential.json.sample` to `credential.json`
+   ```bash
+   $ mv credential.json.sample credential.json
+   ```
+
 # How to use
 1. Setup NI ( Network Interface )
    ```bash
@@ -22,14 +34,18 @@ A collection of programs created to implement a configurator for Wi-Fi Easy Conn
    ```
 
 3. Run dpp-configurator
-   
+
    1. main branch version
       ```bash
       $ sudo ./dpp-configurator <NI_NAME> 
       ```
    2. dev branch version
       ```bash
-      $ sudo ./dpp-configurator <NI_NAME> <Public_Key (included in QR code)>
+      $ sudo ./dpp-configurator <NI_NAME> <Public_Key (included in QR code)> <Enrollee_MAC_ADDR> <Configurator_MAC_ADDR>
+      ```
+   3. dev branch version (sample)
+      ```
+      $ sudo ./dpp-configurator wap5e1 MDkwEw ... fYswnE= 12:34:56:78:90:ab cd:ef:gh:ij:kl:mn  
       ```
 4. Restore the Environment
    ```bash

--- a/README.md
+++ b/README.md
@@ -22,10 +22,15 @@ A collection of programs created to implement a configurator for Wi-Fi Easy Conn
    ```
 
 3. Run dpp-configurator
-   ```bash
-   $ sudo ./dpp-configurator <NI_NAME>
-   ```
-
+   
+   1. main branch version
+      ```bash
+      $ sudo ./dpp-configurator <NI_NAME> 
+      ```
+   2. dev branch version
+      ```bash
+      $ sudo ./dpp-configurator <NI_NAME> <Public_Key (included in QR code)>
+      ```
 4. Restore the Environment
    ```bash
    $ ./finish.sh <NI_NAME>

--- a/credential.json.sample
+++ b/credential.json.sample
@@ -1,0 +1,1 @@
+{"wi-fi_tech":"infra","discovery":{"ssid":"<SSID>"},"cred":{"akm":"psk","pass":"<PASSWORD>"}}

--- a/dpp-configurator.c
+++ b/dpp-configurator.c
@@ -134,6 +134,7 @@ uint8_t radiotap_header[] = {
 // 鍵の情報を保持しておく構造体
 typedef struct 
 {
+    char QR_Key[81];
     uint8_t Ini_Proto_Key[64];
     uint8_t Ini_Boot_key[32];
     uint8_t Res_Proto_Key[64];
@@ -340,15 +341,19 @@ void create_dpp_auth_conf_frame(uint8_t *frame, size_t *frame_len);
 void create_dpp_conf_res_frame(uint8_t *frame, size_t *frame_len);
 
 int main(int argc, char*argv[]) {
-    if (argc != 2)
+    if (argc != 3)
     {
-        printf("Usage: %s <interface_name>\n", argv[0]);
+        printf("Usage: %s <interface_name> <Pub_Boot_Key>\n", argv[0]);
         return 1;
     }
     
     char errbuf[PCAP_ERRBUF_SIZE];
     pcap_t *handle;
-    char *dev = argv[1]; // 使用するインターフェイス名
+    char *dev = argv[1];
+    
+    memcpy(auth.QR_Key, argv[2], 81);
+
+     // 使用するインターフェイス名
     // デバイスをオープン
     handle = pcap_open_live(dev, BUFSIZ, 1, 1000, errbuf);
     if (handle == NULL) {
@@ -612,10 +617,10 @@ void create_dpp_auth_req_frame(uint8_t *frame, size_t *frame_len) {
     unsigned char Res_bootkey_hash[SHA256_DIGEST_LENGTH];
     size_t data_len;
     size_t key_len;
-    const char key[81] = "MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACCcWFqRtN+f0loEUgGIXDnMXPrjl92u2pV97Ff6DjUD8="; // QRコードに書かれている文字列
+    //const char key[81] = "MDkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDIgACCcWFqRtN+f0loEUgGIXDnMXPrjl92u2pV97Ff6DjUD8="; // QRコードに書かれている文字列
     unsigned char *der_data;
 
-    der_data = (unsigned char *)base64_gen_decode(key, 81, &data_len, base64_table);
+    der_data = (unsigned char *)base64_gen_decode(auth.QR_Key, 81, &data_len, base64_table);
 
     if (sha256_vector(1, (const u8 **)&der_data, &data_len, Res_bootkey_hash))
     {

--- a/dpp-configurator.c
+++ b/dpp-configurator.c
@@ -391,12 +391,6 @@ int main(int argc, char*argv[]) {
 
             if (res == 1)
             {
-
-                //struct ieee80211_radiotap_header *rtheader = (struct ieee80211_radiotap_header *)packet0;
-                //int rtap_len = rtheader->it_len;
-
-                //ieee80211_header_t *macheader = (ieee80211_header_t *)(packet0 + rtap_len);
-
                 // パケットを受信した場合、パケットの解析を行う
                 if (compare_mac_addr(packet0) == 0 ){
                     // パケットを構造体に格納


### PR DESCRIPTION
## Updated to allow provisioning of two enrollees at the same time
+ Changed to accept as arguments the card name of the NIC, the public key contained in the QR code, the MAC address of the configurator, and the MAC address of the Enrollee.
+ Updated to check the length of Radiotap-header and then separate packets.